### PR TITLE
Fix override ally drivers issue

### DIFF
--- a/src/AllyManager.js
+++ b/src/AllyManager.js
@@ -54,7 +54,7 @@ class AllyManager {
       throw GE.InvalidArgumentException.invalidParameter('Cannot get driver instance without a name')
     }
 
-    const Driver = Drivers[name.toLowerCase()] || this._drivers[name.toLowerCase()]
+    const Driver = this._drivers[name.toLowerCase()] || Drivers[name.toLowerCase()]
     if (!Driver) {
       throw GE.InvalidArgumentException.invalidParameter(`${name} is not a valid ally driver`)
     }


### PR DESCRIPTION
As you may know, the LinkedIn driver is not working for API v2 (#69). I'm trying to implement a new driver for Linkedin which is compatible with API V2. Here's the code I use to extend Ally in hooks.js:
 ```
ioc.extend('Adonis/Addons/Ally', 'linkedin', () => {     
    return new linkedin(Config);
});
 ```
The main problem is that you can extend Ally using a new key but can't override existing drivers. To solve this issue I gave priority to extended drivers in AllyManager.