### PR TITLE
Allow to dynamically add parameters to redirect URI

### DIFF
--- a/src/Authenticator.js
+++ b/src/Authenticator.js
@@ -95,6 +95,23 @@ class Authenticator {
   }
 
   /**
+   * Allow to dynamically append parameters to the URI of the driver.
+   * This function needs to be called every time the driver is instantiated.
+   *
+   * Example:
+   * ally.driver("facebook").withAdditionalParams(params).redirect()
+   * ally.driver("facebook").withAdditionalParams(params).getUser()
+   *
+   * @method withAdditionalParams
+   * @param additionalParams
+   * @returns {Authenticator}
+   */
+  withAdditionalParams(additionalParams) {
+    this._driverInstance.withAdditionalParams(additionalParams);
+    return this;
+  }
+
+  /**
    * Redirects request to the provider website url.
    *
    * @method redirect

--- a/src/Schemes/OAuth2.js
+++ b/src/Schemes/OAuth2.js
@@ -131,6 +131,24 @@ class OAuth2 {
   }
 
   /**
+   * Allow to dynamically append parameters to the URI of the driver.
+   * This function needs to be called every time the driver is instantiated.
+   *
+   * @method withAdditionalParams
+   *
+   * @param {URLSearchParams} additionalParams
+   *
+   * @return {void}
+   */
+  withAdditionalParams(additionalParams) {
+    if (this._redirectUri.indexOf("?") > -1) {
+      this._redirectUri += "&" + additionalParams.toString();
+    } else {
+      this._redirectUri += "?" + additionalParams.toString();
+    }
+  }
+
+  /**
    * Returns a formatted url to be used for redirecting
    * users.
    *


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Allow to dynamically add parameters to providers' redirect URI. I've tested this with:
- facebook: allows this without much hassle. The redirect URI set in the facebook app needs only to match the "path" part of the URL
- google: in the google app you need to set the full url with all the additional parameters, so it's not technically dynamic, but it works for me

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-ally/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
