### PR TITLE
fix (facebook): obtain profile picture from user profile

### DIFF
--- a/src/Drivers/Facebook.js
+++ b/src/Drivers/Facebook.js
@@ -44,7 +44,7 @@ class Facebook extends OAuth2Scheme {
      * Public fields to be mutated from outside
      */
     this.scope = _.size(config.scope) ? config.scope : ['email']
-    this.fields = _.size(config.fields) ? config.fields : ['name', 'email', 'gender', 'verified', 'link']
+    this.fields = _.size(config.fields) ? config.fields : ['name', 'email', 'gender', 'verified', 'link', 'picture']
   }
 
   /**
@@ -157,15 +157,13 @@ class Facebook extends OAuth2Scheme {
     const user = new AllyUser()
     const expires = _.get(accessTokenResponse, 'result.expires_in')
 
-    const avatarUrl = `${this.baseUrl}/${userProfile.id}/picture?type=normal`
-
     user.setOriginal(userProfile)
       .setFields(
         userProfile.id,
         userProfile.name,
         userProfile.email,
         userProfile.name,
-        avatarUrl
+        userProfile.picture ? userProfile.picture.data.url : null
       )
       .setToken(
         accessTokenResponse.accessToken,


### PR DESCRIPTION
(these pull requests are done to maintain ally 4.1... someone is still using this probably)
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Profile picture via Facebook graph API is no longer possible. Profile picture is actually already returned when we get user profile from Facebook, under picture.data.url

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-ally/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
