### PR TITLE
Fixed missing `identify` scope for Discord OAuth2

### DIFF
--- a/src/Drivers/Discord/index.ts
+++ b/src/Drivers/Discord/index.ts
@@ -77,7 +77,7 @@ export class DiscordDriver
     /**
      * Define user defined scopes or the default one's
      */
-    request.scopes(this.config.scopes || ['email'])
+    request.scopes(this.config.scopes || ['identify', 'email'])
 
     request.param('response_type', 'code')
     request.param('grant_type', 'authorization_code')


### PR DESCRIPTION
## Proposed changes

Just added `identify`  scope to the default required scopes.  Without this `identify` scope, the Discord API throw an "Unauthorized" (401) error.
Fix #127 

## Types of changes
Bug fixing 

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-ally/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
