### PR TITLE
[eyglys] resolve duplicated set-cookie

### DIFF
--- a/src/AbstractDrivers/Oauth1/index.ts
+++ b/src/AbstractDrivers/Oauth1/index.ts
@@ -154,14 +154,18 @@ export abstract class Oauth1Driver<Token extends Oauth1AccessToken, Scopes exten
     /**
      * Read and cache in-memory
      */
-    this.oauthTokenCookieValue = this.ctx.request.encryptedCookie(this.oauthTokenCookieName)
-    this.oauthSecretCookieValue = this.ctx.request.encryptedCookie(this.oauthSecretCookieName)
+    this.oauthTokenCookieValue = this.ctx.request.encryptedCookie(this.oauthTokenCookieName, null)
+    this.oauthSecretCookieValue = this.ctx.request.encryptedCookie(this.oauthSecretCookieName, null)
 
     /**
      * Clear cookies
      */
-    this.ctx.response.clearCookie(this.oauthTokenCookieName)
-    this.ctx.response.clearCookie(this.oauthSecretCookieName)
+    if (this.oauthTokenCookieValue) {
+      this.ctx.response.clearCookie(this.oauthTokenCookieName)
+    }
+    if (this.oauthSecretCookieValue) {
+      this.ctx.response.clearCookie(this.oauthSecretCookieName)
+    }
   }
 
   /**

--- a/src/AbstractDrivers/Oauth2/index.ts
+++ b/src/AbstractDrivers/Oauth2/index.ts
@@ -148,8 +148,10 @@ export abstract class Oauth2Driver<Token extends Oauth2AccessToken, Scopes exten
       return
     }
 
-    this.stateCookieValue = this.ctx.request.encryptedCookie(this.stateCookieName)
-    this.ctx.response.clearCookie(this.stateCookieName)
+    this.stateCookieValue = this.ctx.request.encryptedCookie(this.stateCookieName, null)
+    if (this.stateCookieValue) {
+      this.ctx.response.clearCookie(this.stateCookieName)
+    }
   }
 
   /**


### PR DESCRIPTION
## Proposed changes

Avoid executing clearCookie on AbstractDrivers/Oauth2.loadState method (also on Oauth1) when the cookie does not exist. This bugfix resolves issue #133.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-ally/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

The use of ally and web sessions (via cookie) sent two set-cookies to the browser. One such set-cookie was a clear (performed by clearCookie). The result of this was the loss of state between the Adonis application and the authentication service.

The bug is described in issue #133 .

The clearCookie should only be run when there is a state cookie (otherwise it will send a set-cookie).
