### PR TITLE
fix(google): correctly retrieve idToken

### DIFF
--- a/adonis-typings/ally.ts
+++ b/adonis-typings/ally.ts
@@ -370,6 +370,8 @@ declare module '@ioc:Adonis/Addons/Ally' {
    * Shape of the Google access token
    */
   export type GoogleToken = Oauth2AccessToken & {
+    // @deprecated Use `idToken` instead
+    id_token: string
     idToken: string
     grantedScopes: string[]
   }

--- a/src/Drivers/Google/index.ts
+++ b/src/Drivers/Google/index.ts
@@ -186,6 +186,18 @@ export class GoogleDriver
   }
 
   /**
+   * Get access token
+   */
+  public async accessToken(callback?: (request: ApiRequestContract) => void): Promise<GoogleToken> {
+    const token = await super.accessToken(callback)
+
+    return {
+      ...token,
+      idToken: token.id_token,
+    }
+  }
+
+  /**
    * Returns details for the authorized user
    */
   public async user(callback?: (request: ApiRequestContract) => void) {


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds the field `idToken` in the payload given by Google.
We also deprecate the `id_token` field that was never documented but may be used by others.

Note that I haven't been able to try the code.

Closes https://github.com/adonisjs/ally/issues/140