### PR TITLE
Fix Authorization URL Update discord.ts

### DIFF
--- a/src/drivers/discord.ts
+++ b/src/drivers/discord.ts
@@ -24,7 +24,7 @@ import { Oauth2Driver } from '../abstract_drivers/oauth2.js'
  */
 export class DiscordDriver extends Oauth2Driver<DiscordToken, DiscordScopes> {
   protected accessTokenUrl = 'https://discord.com/api/oauth2/token'
-  protected authorizeUrl = 'https://discord.com/api/oauth2/authorize'
+  protected authorizeUrl = 'https://discord.com/oauth2/authorize'
   protected userInfoUrl = 'https://discord.com/api/users/@me'
 
   /**
@@ -82,6 +82,7 @@ export class DiscordDriver extends Oauth2Driver<DiscordToken, DiscordScopes> {
 
     request.param('response_type', 'code')
     request.param('grant_type', 'authorization_code')
+    request.param('integration_type', 1)
 
     /**
      * Define params based upon user config


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I have fixed the url used for Discord oath2 authorization. It required the removal of the `/api` part in the route in accordance with Discords OAuth2 documentation (read here: https://discord.com/developers/docs/topics/oauth2).

Furthermore, I added a parameter to the request called "integration_type" and I set the value to 1. Though the Discord documentation states that it is unnecessary unless a specific scope is being called, I kept receiving an error that said "Installation type not supported for this application". I solved it by adding the integration type and setting it to user install.

### 📝 Checklist

I have not linked an issue or discussion, as I did not see one. I also do not believe this change will require any change to the documentation.

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
