### PR TITLE
fix: add name fallback for GitHub users

### DIFF
--- a/src/drivers/github.ts
+++ b/src/drivers/github.ts
@@ -142,7 +142,7 @@ export class GithubDriver extends Oauth2Driver<GithubToken, GithubScopes> {
       emailVerificationState: (body.email
         ? 'verified'
         : 'unsupported') as AllyUserContract<any>['emailVerificationState'],
-      name: body.name,
+      name: body.name ?? body.login,
       avatarUrl: body.avatar_url,
       original: body,
     }


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

#150 

### ❓ Type of change

Ensure users will always have a name, even if no display name is defined on their GitHub account. This is done by doing a fallback on the login name.

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #150 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
