### PR TITLE
Fix discord integration

### DIFF
--- a/src/drivers/discord.ts
+++ b/src/drivers/discord.ts
@@ -25,7 +25,7 @@ import { Oauth2Driver } from '../abstract_drivers/oauth2.js'
 export class DiscordDriver extends Oauth2Driver<DiscordToken, DiscordScopes> {
   protected accessTokenUrl = 'https://discord.com/api/oauth2/token'
   protected authorizeUrl = 'https://discord.com/oauth2/authorize'
-  protected userInfoUrl = 'https://discord.com/api/users/@me'
+  protected userInfoUrl = 'https://discord.com/oauth2/@me'
 
   /**
    * The param name for the authorization code
@@ -131,18 +131,18 @@ export class DiscordDriver extends Oauth2Driver<DiscordToken, DiscordScopes> {
 
     const body = await request.get()
     return {
-      id: body.id,
-      name: `${body.username}#${body.discriminator}`,
-      nickName: body.username,
-      avatarUrl: body.avatar
-        ? `https://cdn.discordapp.com/avatars/${body.id}/${body.avatar}.${
-            body.avatar.startsWith('a_') ? 'gif' : 'png'
+      id: body.user.id,
+      name: `${body.user.username}#${body.user.discriminator}`,
+      nickName: body.user.username,
+      avatarUrl: body.user.avatar
+        ? `https://cdn.discordapp.com/avatars/${body.user.id}/${body.user.avatar}.${
+            body.user.avatar.startsWith('a_') ? 'gif' : 'png'
           }`
-        : `https://cdn.discordapp.com/embed/avatars/${body.discriminator % 5}.png`,
-      email: body.email, // May not always be there (requires email scope)
+        : `https://cdn.discordapp.com/embed/avatars/${body.user.discriminator % 5}.png`,
+      email: body.user.email, // May not always be there (requires email scope)
       emailVerificationState:
         'verified' in body
-          ? body.verified
+          ? body.user.verified
             ? ('verified' as const)
             : ('unverified' as const)
           : ('unsupported' as const),

--- a/src/drivers/discord.ts
+++ b/src/drivers/discord.ts
@@ -75,13 +75,15 @@ export class DiscordDriver extends Oauth2Driver<DiscordToken, DiscordScopes> {
    * Configuring the redirect request with defaults
    */
   protected configureRedirectRequest(request: RedirectRequestContract<DiscordScopes>) {
+    request.param('response_type', 'code')
+
     /**
      * Define user defined scopes or the default one's
      */
     request.scopes(this.config.scopes || ['identify', 'email'])
-
-    request.param('response_type', 'code')
-    request.param('grant_type', 'authorization_code')
+    
+    // User installation: the application will be authorized for installation to a user, 
+    // not an entire guild.
     request.param('integration_type', 1)
 
     /**
@@ -89,15 +91,8 @@ export class DiscordDriver extends Oauth2Driver<DiscordToken, DiscordScopes> {
      */
     if (this.config.prompt) {
       request.param('prompt', this.config.prompt)
-    }
-    if (this.config.guildId) {
-      request.param('guild_id', this.config.guildId)
-    }
-    if (this.config.disableGuildSelect !== undefined) {
-      request.param('disable_guild_select', this.config.disableGuildSelect)
-    }
-    if (this.config.permissions !== undefined) {
-      request.param('permissions', this.config.permissions)
+    } else {
+      request.param('prompt', 'consent')
     }
   }
 


### PR DESCRIPTION
In Ally we're authorizing users, not requesting an access token for a bot, as such, the guild and permissions parameters are not valid: https://discord.com/developers/docs/topics/oauth2#bot-users

We're also using the user integration type, since that's the purpose of Ally: to authenticate users.

### 🔗 Linked issue

I didn't open an issue, instead went straight for a PR to fix.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Aligns the oauth redirect parameters with those documented in the Discord docs for user authorization.

https://discord.com/developers/docs/topics/oauth2#authorization-code-grant

Previously we had parameters that were only applicable for bot-user authentication, which isn't what Ally is being used for here.

I've also corrected the userinfo URL.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
